### PR TITLE
Update huc-v2-upsell-item-slide background color

### DIFF
--- a/Amazon-Theme-Dark.user.css
+++ b/Amazon-Theme-Dark.user.css
@@ -652,6 +652,9 @@ div[style="background-color: white;padding-bottom:20px;"] {
 .huc-v2-pinned-order-row-with-divider {
     background-color: #1c1f26 !important;
 }
+.huc-v2-upsell-item-slide {
+    background-color: rgba(28, 31, 38, 0.95) !important;
+}
 #DP_IMAGE_GALLERY_BUTTON_CONTAINER .image-thumbnails {
     width: 22.5%;
     height: auto;


### PR DESCRIPTION
Change the background color of the hover slide out info panels (visible after adding an item to a cart).

The `rgba` equivalent for `#1c1f26`  is used because the default value is `rgba(255, 255, 255, 0.95)`. The default white background of this element provides no contrast for the white text in this style.